### PR TITLE
escapeHtmlByDefault:true

### DIFF
--- a/lib/haml-sprockets.rb
+++ b/lib/haml-sprockets.rb
@@ -14,7 +14,7 @@ module Haml
       def evaluate(scope,locals,&block)
         haml_code = data.dup
         haml_code = haml_code.gsub(/\\/,"\\\\").gsub(/\'/,"\\'").gsub(/\n/,"\\n")
-        "Haml('#{haml_code}')"
+        "Haml('#{haml_code}', {escapeHtmlByDefault:true})"
       end
     end
   end


### PR DESCRIPTION
I think it's preferable if the = operator escapes html by default
