### PR TITLE
Remove the outdated "require 'haml'" reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ In the `Gemfile`, add the following line.
 
     gem "haml-sprockets"
 
-In `app/assets/javascripts/application.js` add the following line before `//= require_tree .`
-
-    //=require haml
-
 Now, you can create hamljs files under `app/assets/javascripts/templates` folder. You can create the templates folder, if it does not already exist.
 
     // code for app/assets/javascripts/templates/hello.jst.hamljs


### PR DESCRIPTION
Not sure if this is correct, but it seems that the new version already compiles the templates on the server, and doesn't depend on the Haml runtime in the browser.
